### PR TITLE
Allow hardcoded validator keys

### DIFF
--- a/metrics/deposits.go
+++ b/metrics/deposits.go
@@ -5,6 +5,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"runtime"
 	"time"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
 // TODO: Temporal solution:
@@ -13,12 +14,20 @@ import (
 // - Fetches the deposits every hour
 func (a *Metrics) StreamDeposits() {
 	for {
+		/*
 		pubKeysDeposited, err := a.theGraph.GetAllDepositedKeys()
 		if err != nil {
 			log.Error(err)
 			time.Sleep(10 * 60 * time.Second)
 			continue
 		}
+		*/
+
+		pubKeysDeposited, err := getHardcodedKeys()
+		if err != nil {
+			log.Fatal(err)
+		}
+
 		a.depositedKeys = pubKeysDeposited
 
 		log.WithFields(log.Fields{
@@ -34,4 +43,23 @@ func (a *Metrics) StreamDeposits() {
 
 		time.Sleep(60 * 60 * time.Second)
 	}
+}
+
+func getHardcodedKeys() ([][]byte, error) {
+	// Kintsugi validators
+	var keysStr = []string{
+		"0x820575d85e0368bc5f2aa55a9b3a41ea804afe28b031a84f4b8a66b9a3c6b6ab39d6f46e020b860d6cbfa987248e92d6",
+		"0x935daecc77617f127226edff6af7100fdbea02477bb9376608492a0b5c9706e30f8911f5075563e140afa182df22abfb",
+	}
+
+	keys := make([][]byte, 0)
+
+	for _, keyStr := range keysStr {
+		key, err := hexutil.Decode(keyStr)
+		keys = append(keys, key)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return keys, nil
 }


### PR DESCRIPTION
- Currently, the validator keys are fetched by the `from-address` or `withdrawal-credentials`. This PR allows to hardcode the keys, useful when a static set of validators wants to be monitored. Both options will be supported.
- Note that if keys are static, `from-address` and `withdrawal-credentials` no longer make sense.
- The main use case so far is to monitor "the merge" testnet, where a set of hardcoded validators can be mapped to a different client.