### PR TITLE
Add GetPoolKeys from db function

### DIFF
--- a/metrics/deposits.go
+++ b/metrics/deposits.go
@@ -2,9 +2,10 @@ package metrics
 
 import (
 	//"github.com/alrevuelta/eth-pools-metrics/prometheus"
-	log "github.com/sirupsen/logrus"
 	"runtime"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // TODO: Temporal solution:
@@ -13,16 +14,25 @@ import (
 // - Fetches the deposits every hour
 func (a *Metrics) StreamDeposits() {
 	for {
+
 		pubKeysDeposited, err := a.theGraph.GetAllDepositedKeys()
 		if err != nil {
 			log.Error(err)
 			time.Sleep(10 * 60 * time.Second)
 			continue
 		}
+		/* TODO: Check that postgresql is set
+		pubKeysDeposited, err := a.postgresql.GetPoolKeys(a.PoolName)
+		if err != nil {
+			log.Error(err)
+			continue
+		}
+		*/
+
 		a.depositedKeys = pubKeysDeposited
 
 		log.WithFields(log.Fields{
-			"DepositedValidators": len(pubKeysDeposited),
+			"DepositedValidators": len(a.depositedKeys),
 			// TODO: Print epoch
 			//"Slot":     slot,
 			//"Epoch":    uint64(slot) % a.slotsInEpoch,

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -2,14 +2,16 @@ package metrics
 
 import (
 	"context"
+	"time"
+
 	"github.com/alrevuelta/eth-pools-metrics/config"
 	"github.com/alrevuelta/eth-pools-metrics/postgresql"
-	"github.com/alrevuelta/eth-pools-metrics/prysm-concurrent"
+	prysmconcurrent "github.com/alrevuelta/eth-pools-metrics/prysm-concurrent"
 	"github.com/alrevuelta/eth-pools-metrics/thegraph"
 	"github.com/pkg/errors"
 	ethpb "github.com/prysmaticlabs/prysm/v2/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v2/time/slots"
-	"time"
+
 	//log "github.com/sirupsen/logrus"
 	ethTypes "github.com/prysmaticlabs/eth2-types"
 	"google.golang.org/grpc"


### PR DESCRIPTION
- Add `GetPoolKeys`, that reads from a postgres database the validator keys and their labels (i.e. pool name). Aiming to be integrated with [kintsugi-deposits](https://github.com/alrevuelta/kintsugi-deposits).
- Note that a postgres db must be running at `postgresql://user:password@netloc:port/dbname` configured with the `postgres` flag.
- The table must be named `t_deposits` and it must have the following fields: `f_index`, `f_key`, `f_pool`